### PR TITLE
Handle 3-character hex codes and non-hex input

### DIFF
--- a/ColorPicker.js
+++ b/ColorPicker.js
@@ -422,6 +422,9 @@ module.exports = class ColorPicker extends Component {
 		this.props.onColorChange(hsv2Hex(hsv))
 	}
 	update = (color, who, max, force) => {
+		const isHex = /^#(([0-9a-f]{2}){3}|([0-9a-f]){3})$/i
+		if (!isHex.test(color)) color = '#ffffff'
+		if (color.length === 4) color = `#${color[1]}${color[1]}${color[2]}${color[2]}${color[3]}${color[3]}`
 		const specific = (typeof who == 'string'), who_hs = (who=='hs'), who_v = (who=='v')
 		let {h, s, v} = (typeof color == 'string') ? hex2Hsv(color) : color, stt = {}
 		h = (who_hs||!specific) ? h : this.color.h


### PR DESCRIPTION
This ensures the component doesn't break when the input to color is

1. 3 digit hex codes
2. Non-hex

Support for 3 digit hex codes is in the form of transforming it into 6-digit hex codes