### PR TITLE
Update types.d.ts - added param value to onColorChange & onColorChangeComplete

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -13,8 +13,8 @@ export interface ColorPickerProps extends React.Props<ColorPicker> {
   shadeWheelThumb: boolean,
   shadeSliderThumb: boolean,
   autoResetSlider: boolean,
-  onColorChange(): void,
-  onColorChangeComplete(): void,
+  onColorChange(value: string): void,
+  onColorChangeComplete(value: string): void,
 }
 
 declare class ColorPicker extends React.Component<ColorPickerProps, any> {


### PR DESCRIPTION
Added param value to be returned on the `onColorChange` & `onColorChangeComplete` callbacks.

Currently TS will throw an error because the current TS definition doesn't return the color parameter.

![Screenshot 2021-06-24 at 09 49 18](https://user-images.githubusercontent.com/3584560/123215743-7ddfbb80-d4d1-11eb-9b14-8f0093665f3c.png)
