### PR TITLE
Optional callback fired when gesture interactions first start

### DIFF
--- a/ColorPicker.js
+++ b/ColorPicker.js
@@ -172,6 +172,7 @@ module.exports = class ColorPicker extends Component {
 		shadeWheelThumb: true,
 		shadeSliderThumb: false,
 		autoResetSlider: false,
+		onInteractionStart: () => {},
 		onColorChange: () => {},
 		onColorChangeComplete: () => {},
 	}
@@ -191,6 +192,7 @@ module.exports = class ColorPicker extends Component {
 			const x = x0 - locationX, y = y0 - locationY
 			this.wheelMeasure.x = x
 			this.wheelMeasure.y = y
+			this.props.onInteractionStart();
 			return true
 		},
 		onPanResponderMove: (event, gestureState) => {
@@ -227,6 +229,7 @@ module.exports = class ColorPicker extends Component {
 			const x = x0 - locationX, y = y0 - locationY
 			this.sliderMeasure.x = x
 			this.sliderMeasure.y = y
+			this.props.onInteractionStart();
 			return true
 		},
 		onPanResponderMove: (event, gestureState) => {

--- a/README.md
+++ b/README.md
@@ -83,9 +83,11 @@ export default App
 
 `autoResetSlider: false` if true the slider thumb is reset to 0 value when wheel thumb is moved
 
-`onColorChange: (color) => {}` callback function for slider and wheel thumb movement
+`onInteractionStart: () => {}` callback function triggered when user begins dragging slider/wheel
 
-`onColorChangeComplete: (color) => {}` callback function for when the slider and wheel thumb stops moving
+`onColorChange: (color) => {}` callback function providing current color while user is actively dragging slider/wheel
+
+`onColorChangeComplete: (color) => {}` callback function providing final color when user stops dragging slider/wheel
 
 ## Instance methods
 `revert()` reverts the color to the one provided in the color prop

--- a/types.d.ts
+++ b/types.d.ts
@@ -25,9 +25,11 @@ export interface ColorPickerProps extends React.Props<ColorPicker> {
   shadeSliderThumb?: boolean,
   /** If true the slider thumb is reset to 0 value when wheel thumb is moved */
   autoResetSlider?: boolean,
-  /** Callback function for slider and wheel thumb movement */
+  /** Callback function triggered when user begins dragging slider/wheel */
+  onInteractionStart?: () => void,
+  /** Callback function providing current color while user is actively dragging slider/wheel */
   onColorChange?: (color: string) => void,
-  /** Callback function for when the slider and wheel thumb stops moving */
+  /** Callback function providing final color when user stops dragging slider/wheel */
   onColorChangeComplete?: (color: string) => void,
 }
 


### PR DESCRIPTION
## Description
Added an optional callback triggered by slider & wheel `onPanResponderGrant` functions to perform any additional setup when interactions first start.

## Use case
If wheel/slider are nested in a ScrollView, interacting with the wheel/slider also propagates up to the ScrollView rendering the color wheel/slider practically unusable. 

I tried using `onColorChange` to disable the ScrollView via `scrollRef.current.setNativeProps({scrollEnabled: false})` & re-enabling it in `onColorChangeCompleted` however performance was really poor (even if I used a flag to prevent updating the native props more than once).

By utilizing a callback that's triggered only when a gesture first begins, it's possible to disable scrolling and avoid conflicts with other gesture handlers without impacting the performance of mid-gesture color updates via `onColorChange`. 
