### PR TITLE
Optional hitSlop for swatches

### DIFF
--- a/ColorPicker.js
+++ b/ColorPicker.js
@@ -168,6 +168,7 @@ module.exports = class ColorPicker extends Component {
 		swatches: true,
 		swatchesLast: true,
 		swatchesOnly: false,
+		swatchesHitSlop: undefined,
 		color: '#ffffff',
 		shadeWheelThumb: true,
 		shadeSliderThumb: false,
@@ -499,8 +500,8 @@ module.exports = class ColorPicker extends Component {
 	}
 	renderSwatches () {
 		this.swatches = PALLETE.map((c,i) => (
-			<View style={[ss.swatch,{backgroundColor:c}]} key={'S'+i}>
-				<TouchableWithoutFeedback onPress={x=>this.onSwatchPress(c,i)}>
+			<View style={[ss.swatch,{backgroundColor:c}]} key={'S'+i} hitSlop={this.props.swatchesHitSlop}>
+				<TouchableWithoutFeedback onPress={x=>this.onSwatchPress(c,i)} hitSlop={this.props.swatchesHitSlop}>
 					<Animated.View style={[ss.swatchTouch,{backgroundColor:c,transform:[{scale:this.swatchAnim[i].interpolate({inputRange:[0,0.5,1],outputRange:[0.666,1,0.666]})}]}]} />
 				</TouchableWithoutFeedback>
 			</View>

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ export default App
 
 `swatchesOnly: false` show swatch only and hide wheel and slider
 
+`swatchesHitSlop: undefined` defines how far the touch event can start away from the swatch
+
 `color: '#ffffff'` color of the color picker
 
 `shadeWheelThumb: true` if true the wheel thumb color is shaded

--- a/types.d.ts
+++ b/types.d.ts
@@ -17,6 +17,8 @@ export interface ColorPickerProps extends React.Props<ColorPicker> {
   swatchesLast?: boolean,
   /** Show swatch only and hide wheel and slider */
   swatchesOnly?: boolean,
+  /** Defines how far the touch event can start away from the swatch */
+  swatchesHitSlop?: {top: number, left: number, bottom: number, right: number},
   /** Color of the color picker */
   color?: string,
   /** If true the wheel thumb color is shaded */


### PR DESCRIPTION
### Why ?

When you try to **touch a swatch**, you can **miss the target when its size is too small**. 

Typical interface guidelines recommend touch targets that are at least 30 - 40 points/density-independent pixels. 
(cf [react-native.dev](https://reactnative.dev/docs/view#hitslop))

Add a `hitSlop` attribut for swatches can be better for the user.

### Changes 
Added optional hitSlop for swatches:

- named `swatchesHitSlop` as props,
- `undefined` as default props,
- typed `{top: number, left: number, bottom: number, right: number}`