### PR TITLE
Flag to hide color wheel

### DIFF
--- a/ColorPicker.js
+++ b/ColorPicker.js
@@ -600,8 +600,8 @@ module.exports = class ColorPicker extends Component {
 		return (
 			<View style={[ss.root,row?{flexDirection:'row'}:{},style]}>
 				{ swatches && !swatchesLast && <View style={[ss.swatches,swatchStyle,swatchFirstStyle]} key={'SW'}>{ this.swatches }</View> }
-				{ !swatchesOnly && <View style={[ss.wheel]} key={'$1'} onLayout={this.onSquareLayout}>
-					{ !this.wheelHidden && this.wheelWidth>0 && <View style={[{padding:thumbSize/2,width:this.wheelWidth,height:this.wheelWidth}]}>
+				{ !this.props.wheelHidden && !swatchesOnly && <View style={[ss.wheel]} key={'$1'} onLayout={this.onSquareLayout}>
+					{ this.wheelWidth>0 && <View style={[{padding:thumbSize/2,width:this.wheelWidth,height:this.wheelWidth}]}>
 						<View style={[ss.wheelWrap]}>
 							<Image style={ss.wheelImg} source={srcWheel} />
 							<Animated.View style={[ss.wheelThumb,wheelThumbStyle,Elevations[4],{pointerEvents:'none'}]} />

--- a/ColorPicker.js
+++ b/ColorPicker.js
@@ -171,6 +171,7 @@ module.exports = class ColorPicker extends Component {
 		discrete: false, // use swatchs of shades instead of slider
 		discreteLength: 10, // number of swatchs of shades
 		sliderHidden: false, // if true the slider is hidden
+		wheelHidden: false, // if true the wheel is hidden
 		swatches: true, // show color swatches
 		swatchesLast: true, // if false swatches are shown before wheel
 		swatchesOnly: false, // show swatch only and hide wheel and slider
@@ -600,7 +601,7 @@ module.exports = class ColorPicker extends Component {
 			<View style={[ss.root,row?{flexDirection:'row'}:{},style]}>
 				{ swatches && !swatchesLast && <View style={[ss.swatches,swatchStyle,swatchFirstStyle]} key={'SW'}>{ this.swatches }</View> }
 				{ !swatchesOnly && <View style={[ss.wheel]} key={'$1'} onLayout={this.onSquareLayout}>
-					{ this.wheelWidth>0 && <View style={[{padding:thumbSize/2,width:this.wheelWidth,height:this.wheelWidth}]}>
+					{ !this.wheelHidden && this.wheelWidth>0 && <View style={[{padding:thumbSize/2,width:this.wheelWidth,height:this.wheelWidth}]}>
 						<View style={[ss.wheelWrap]}>
 							<Image style={ss.wheelImg} source={srcWheel} />
 							<Animated.View style={[ss.wheelThumb,wheelThumbStyle,Elevations[4],{pointerEvents:'none'}]} />

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ export default App
 
 `sliderHidden: false` if true the slider is hidden
 
+`wheelHidden: false` if true the wheel is hidden
+
 `swatches: true` show color swatches
 
 `swatchesLast: true` if false swatches are shown before wheel

--- a/types.d.ts
+++ b/types.d.ts
@@ -17,6 +17,8 @@ export interface ColorPickerProps extends React.Props<ColorPicker> {
   discreteLength?: number,
   /** If true the slider is hidden */
   sliderHidden?: boolean,
+  /** If true the wheel is hidden */
+  wheelHidden?: boolean,
   /** Show color swatches */
   swatches?: boolean,
   /** If false swatches are shown before wheel */


### PR DESCRIPTION
Added a simple flag to hide the wheel & thumb picker, to use only the swatches / slider.
To use it simply set `wheelHidden` to `false` and only the swatches/slider will remain! Tested using iOS simulator and device