### PR TITLE
Improved UI around when a gesture moves outside the bounds of the control

### DIFF
--- a/ColorPicker.js
+++ b/ColorPicker.js
@@ -228,16 +228,27 @@ module.exports = class ColorPicker extends Component {
 			if (this.props.disabled) return;
 			if (event && event.nativeEvent && typeof event.nativeEvent.preventDefault == 'function') event.nativeEvent.preventDefault()
 			if (event && event.nativeEvent && typeof event.nativeEvent.stopPropagation == 'function') event.nativeEvent.stopPropagation()
+
+			var ev = {
+				nativeEvent: {
+					locationX: event.nativeEvent.locationX,
+					locationY: event.nativeEvent.locationY
+				}
+			}
+
 			if (this.outOfWheel(event.nativeEvent) || this.outOfBox(this.wheelMeasure, gestureState)) {
 				var closest = this.closestPointOnWheel(
 					{ x: this.wheelPosition.x, y: this.wheelPosition.y },
 					{ x: event.nativeEvent.pageX, y: event.nativeEvent.pageY }
 				)
-				event.nativeEvent.locationX = closest.x - this.wheelPosition.x;
-				event.nativeEvent.locationY = closest.y - this.wheelPosition.y;
+				try {
+					ev.nativeEvent.locationX = closest.x - this.wheelPosition.x;
+					ev.nativeEvent.locationY = closest.y - this.wheelPosition.y;
+				}
+				catch (ex) {}
 			}
 			//
-			this.wheelMovement(event, gestureState)
+			this.wheelMovement(ev, gestureState)
 		},
 		onMoveShouldSetPanResponder: () => true,
 		onPanResponderRelease: (event, gestureState) => {

--- a/ColorPicker.js
+++ b/ColorPicker.js
@@ -225,7 +225,6 @@ module.exports = class ColorPicker extends Component {
 			return true
 		},
 		onPanResponderMove: (event, gestureState) => {
-			this.inWheel = true;
 			if (this.props.disabled) return;
 			if (event && event.nativeEvent && typeof event.nativeEvent.preventDefault == 'function') event.nativeEvent.preventDefault()
 			if (event && event.nativeEvent && typeof event.nativeEvent.stopPropagation == 'function') event.nativeEvent.stopPropagation()
@@ -242,7 +241,6 @@ module.exports = class ColorPicker extends Component {
 		},
 		onMoveShouldSetPanResponder: () => true,
 		onPanResponderRelease: (event, gestureState) => {
-			this.inWheel = false;
 			if (this.props.disabled) return;
 			const { nativeEvent } = event
 			const { radius } = this.polar(nativeEvent)

--- a/ColorPicker.js
+++ b/ColorPicker.js
@@ -290,19 +290,20 @@ module.exports = class ColorPicker extends Component {
 			if (this.props.disabled) return;
 			if (event && event.nativeEvent && typeof event.nativeEvent.preventDefault == 'function') event.nativeEvent.preventDefault()
 			if (event && event.nativeEvent && typeof event.nativeEvent.stopPropagation == 'function') event.nativeEvent.stopPropagation()
+
+			var ev = {
+				nativeEvent: {
+					locationX: event.nativeEvent.locationX,
+					locationY: event.nativeEvent.locationY
+				}
+			}
+
 			if (this.outOfSlider(event.nativeEvent) || this.outOfBox(this.sliderMeasure, gestureState)) {
 				var x = event.nativeEvent.pageX - this.sliderPosition.x;
 				var y = event.nativeEvent.pageY - this.sliderPosition.y;
 				if (x < 0) x = 0;
 				if (y < 0) y = 0;
 				const { width, height } = this.sliderMeasure
-
-				var ev = {
-					nativeEvent: {
-						locationX: event.nativeEvent.locationX,
-						locationY: event.nativeEvent.locationY
-					}
-				}
 
 				try {
 					if (this.props.row) {

--- a/ColorPicker.js
+++ b/ColorPicker.js
@@ -296,15 +296,25 @@ module.exports = class ColorPicker extends Component {
 				if (x < 0) x = 0;
 				if (y < 0) y = 0;
 				const { width, height } = this.sliderMeasure
-				if (this.props.row) {
-					event.nativeEvent.locationX = x < 0 ? 0 : this.props.sliderSize;
-					event.nativeEvent.locationY = y > height - width ? height - width : y;
-				} else {
-					event.nativeEvent.locationY = y < 0 ? 0 : this.props.sliderSize;
-					event.nativeEvent.locationX = x > width - height ? width - height : x;
+
+				var ev = {
+					nativeEvent: {
+						locationX: event.nativeEvent.locationX,
+						locationY: event.nativeEvent.locationY
+					}
 				}
+
+				try {
+					if (this.props.row) {
+						ev.nativeEvent.locationX = x < 0 ? 0 : this.props.sliderSize;
+						ev.nativeEvent.locationY = y > height - width ? height - width : y;
+					} else {
+						ev.nativeEvent.locationY = y < 0 ? 0 : this.props.sliderSize;
+						ev.nativeEvent.locationX = x > width - height ? width - height : x;
+					}
+				} catch(ex) {}
 			}
-			this.sliderMovement(event, gestureState)
+			this.sliderMovement(ev, gestureState)
 		},
 		onMoveShouldSetPanResponder: () => true,
 		onPanResponderRelease: (event, gestureState) => {


### PR DESCRIPTION
Using https://iro.js.org/ as the inpiration for this change.

If the gesture moved outside the bounds of the control (outOfSlider) the process would halt, making it quite fiddly to range slide across the outside bounds of the wheel. This change means that when the gesture moves outside that range, the closest point in the wheel is selected. This means that once the control has focus, the whole width/height of the device can be used.

Implemented for both the wheel, and the slider.

